### PR TITLE
add '--format' flag to resources command, allowing markdown output

### DIFF
--- a/pkg/swagger/apiversions/kind.go
+++ b/pkg/swagger/apiversions/kind.go
@@ -2,12 +2,13 @@ package apiversions
 
 import (
 	"fmt"
-	"github.com/mattfenwick/kubectl-schema/pkg/utils"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"regexp"
 	"strings"
+
+	"github.com/mattfenwick/kubectl-schema/pkg/utils"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func ParseKindResults() {
@@ -30,9 +31,9 @@ func ParseKindResults() {
 		//   instead of reading from static file
 
 		headers, rows, err := ReadCSV(fmt.Sprintf("../kube/data/v%s-api-resources.txt", version))
-		utils.DoOrDie(err)
+		utils.Die(err)
 		rsTable, err := NewResourcesTable(version, headers, rows)
-		utils.DoOrDie(err)
+		utils.Die(err)
 
 		fmt.Printf("%s\n", rsTable.KindResourcesTable())
 

--- a/pkg/swagger/cli.go
+++ b/pkg/swagger/cli.go
@@ -11,7 +11,7 @@ import (
 
 func RunRootSchemaCommand() {
 	command := SetupRootSchemaCommand()
-	utils.DoOrDie(errors.Wrapf(command.Execute(), "run root schema command"))
+	utils.Die(errors.Wrapf(command.Execute(), "run root schema command"))
 }
 
 type RootSchemaFlags struct {
@@ -72,7 +72,7 @@ func RunVersionCommand() {
 		"GitSHA":    gitSHA,
 		"BuildTime": buildTime,
 	})
-	utils.DoOrDie(err)
+	utils.Die(err)
 	fmt.Printf("kubectl-schema version: \n%s\n", jsonString)
 }
 
@@ -137,6 +137,8 @@ func SetupShowResourcesCommand() *cobra.Command {
 
 	command.Flags().StringSliceVar(&args.Resources, "resource", []string{}, "resources to include; if empty, include all")
 	command.Flags().StringSliceVar(&args.ApiVersions, "api-version", []string{}, "api versions to include; if empty, include all")
+
+	command.Flags().StringVar(&args.Format, "format", "table", "format to use for output: valid values are 'table' and 'markdown'")
 
 	return command
 }

--- a/pkg/swagger/debug/cli.go
+++ b/pkg/swagger/debug/cli.go
@@ -2,6 +2,8 @@ package debug
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/mattfenwick/collections/pkg/file"
 	"github.com/mattfenwick/collections/pkg/json"
 	"github.com/mattfenwick/collections/pkg/slice"
@@ -9,7 +11,6 @@ import (
 	"github.com/mattfenwick/kubectl-schema/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 func SetupSwaggerDebugCommand() *cobra.Command {
@@ -58,7 +59,7 @@ func RunParse(args *ParseArgs) {
 
 	// must do weird marshal/unmarshal/marshal dance to get struct keys sorted
 	bytes, err := json.MarshalWithOptions(spec, &json.MarshalOptions{EscapeHTML: true, Indent: true, Sort: true})
-	utils.DoOrDie(err)
+	utils.Die(err)
 
 	fmt.Printf("%s\n", bytes)
 }
@@ -94,7 +95,7 @@ func RunAnalyzeSchema(args *AnalyzeSchemaArgs) {
 
 	path := swagger.MakePathFromKubeVersion(swagger.MustVersion(args.Version))
 	specObj, err := json.ParseFile[map[string]interface{}](path)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	//spec := MustReadSwaggerSpecFromGithub(args.Version) // TODO
 
 	//starterPaths := []string{"paths", "definitions"}
@@ -115,7 +116,7 @@ func RunAnalyzeSchemaLatest() {
 		path := fmt.Sprintf("test-schema/%s.txt", version)
 		specBytes := swagger.MustDownloadSwaggerSpec(version)
 		specObj, err := json.Parse[map[string]interface{}](specBytes)
-		utils.DoOrDie(err)
+		utils.Die(err)
 		//spec := MustReadSwaggerSpecFromGithub(args.Version) // TODO
 
 		//starterPathsToInspect := []string{"paths", "definitions"}
@@ -128,7 +129,7 @@ func RunAnalyzeSchemaLatest() {
 		}
 		lines := slice.Map(func(xs []string) string { return strings.Join(xs, " ") }, dedupedPaths)
 		err = file.Write(path, []byte(strings.Join(lines, "\n")), 0644)
-		utils.DoOrDie(err)
+		utils.Die(err)
 		//for _, p := range dedupedPaths {
 		//	fmt.Printf("%s\n", strings.Join(p, " "))
 		//}

--- a/pkg/swagger/debug/schema-analyzer.go
+++ b/pkg/swagger/debug/schema-analyzer.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"fmt"
+
 	"github.com/mattfenwick/collections/pkg/base"
 	"github.com/mattfenwick/collections/pkg/function"
 	"github.com/mattfenwick/collections/pkg/set"
@@ -75,7 +76,7 @@ func BounceMarshalGeneric[A any](in interface{}) (*A, error) {
 func JsonFindPaths(obj interface{}, starterPaths []string) ([][]string, [][]string) {
 	paths := &JsonPaths{}
 	bouncedObj, err := BounceMarshalGeneric[map[string]interface{}](obj)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	JsonFindPathsHelper(*bouncedObj, []string{}, paths)
 
 	trie := NewTrie()

--- a/pkg/swagger/debug/test-schema-parser.go
+++ b/pkg/swagger/debug/test-schema-parser.go
@@ -2,14 +2,15 @@ package debug
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"reflect"
+
 	"github.com/mattfenwick/collections/pkg/file"
 	"github.com/mattfenwick/collections/pkg/json"
 	"github.com/mattfenwick/kubectl-schema/pkg/swagger"
 	"github.com/mattfenwick/kubectl-schema/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
-	"reflect"
 )
 
 func setupTestSchemaParserCommand() *cobra.Command {
@@ -36,29 +37,29 @@ func CheckSchema(dir string, version swagger.KubeVersion) {
 	specBytes := swagger.MustDownloadSwaggerSpec(version)
 	// remove paths
 	specMap, err := json.Parse[map[string]interface{}](specBytes)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	delete(*specMap, "paths")
 	specMapBytes, err := json.MarshalWithOptions(specMap, json.DefaultMarshalOptions)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	// carry on
 	spec, err := json.Parse[swagger.KubeSpec](specMapBytes)
-	utils.DoOrDie(err)
+	utils.Die(err)
 
 	specString, err := json.MarshalToString(spec)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	spec2, err := json.Parse[swagger.KubeSpec]([]byte(specString))
-	utils.DoOrDie(err)
+	utils.Die(err)
 
-	utils.DoOrDie(os.MkdirAll(dir, 0777))
+	utils.Die(os.MkdirAll(dir, 0777))
 	path1, path2 := path.Join(dir, "spec1.txt"), path.Join(dir, "spec2.txt")
 
 	sortedSpecBytes, err := json.SortOptions(specMapBytes, false, true)
-	utils.DoOrDie(err)
-	utils.DoOrDie(file.Write(path1, sortedSpecBytes, 0644))
+	utils.Die(err)
+	utils.Die(file.Write(path1, sortedSpecBytes, 0644))
 
 	sortedSpecStringBytes, err := json.SortOptions([]byte(specString), false, true)
-	utils.DoOrDie(err)
-	utils.DoOrDie(file.Write(path2, sortedSpecStringBytes, 0644))
+	utils.Die(err)
+	utils.Die(file.Write(path2, sortedSpecStringBytes, 0644))
 
 	//diff, err := utils.CommandRun(exec.Command("git", "diff", "--no-index", "my-spec-1.txt", "my-spec-2.txt"))
 	//utils.DoOrDie(err)

--- a/pkg/swagger/explain.go
+++ b/pkg/swagger/explain.go
@@ -45,7 +45,7 @@ func RunExplain(args *ExplainArgs) {
 	//table := NewPivotTable("?", args.KubeVersions)
 
 	for _, kubeVersion := range args.KubeVersions {
-		fmt.Printf("%s\n", kubeVersion)
+		fmt.Printf("for kube version %s\n", kubeVersion)
 		spec := MustReadSwaggerSpecFromGithub(MustVersion(kubeVersion))
 		typesByKindByApiVersion := spec.ResolveStructure()
 

--- a/pkg/swagger/kubeversion.go
+++ b/pkg/swagger/kubeversion.go
@@ -26,7 +26,7 @@ func NewVersion(v string) (KubeVersion, error) {
 
 func MustVersion(v string) KubeVersion {
 	version, err := NewVersion(v)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	return version
 }
 

--- a/pkg/swagger/readspec.go
+++ b/pkg/swagger/readspec.go
@@ -2,13 +2,14 @@ package swagger
 
 import (
 	"fmt"
+	"os"
+	"path"
+
 	"github.com/mattfenwick/collections/pkg/file"
 	"github.com/mattfenwick/collections/pkg/json"
 	"github.com/mattfenwick/kubectl-schema/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"os"
-	"path"
 )
 
 const (
@@ -17,7 +18,7 @@ const (
 
 func getHomeDir() string {
 	home, err := os.UserHomeDir()
-	utils.DoOrDie(errors.Wrapf(err, "unable to get home dir"))
+	utils.Die(errors.Wrapf(err, "unable to get home dir"))
 	return home
 }
 
@@ -53,20 +54,20 @@ func ReadSwaggerSpecFromGithub(version KubeVersion) (*KubeSpec, error) {
 	}
 
 	spec, err := json.ParseFile[KubeSpec](specPath)
-	utils.DoOrDie(err)
+	utils.Die(err)
 
 	return spec, nil
 }
 
 func MustReadSwaggerSpecFromGithub(version KubeVersion) *KubeSpec {
 	spec, err := ReadSwaggerSpecFromGithub(version)
-	utils.DoOrDie(err)
+	utils.Die(err)
 	return spec
 }
 
 func MustDownloadSwaggerSpec(version KubeVersion) []byte {
 	bytes, err := utils.GetURL(version.SwaggerSpecURL())
-	utils.DoOrDie(err)
+	utils.Die(err)
 	return bytes
 }
 

--- a/pkg/swagger/resources.go
+++ b/pkg/swagger/resources.go
@@ -2,12 +2,15 @@ package swagger
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/mattfenwick/collections/pkg/slice"
 	"github.com/mattfenwick/kubectl-schema/pkg/diff"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
+
+// section: types
 
 type ShowResourcesArgs struct {
 	GroupBy      string
@@ -15,6 +18,7 @@ type ShowResourcesArgs struct {
 	ApiVersions  []string
 	Resources    []string
 	Diff         bool
+	Format       string
 	// TODO add flag to verify parsing?  by serializing/deserializing to check if it matches input?
 }
 
@@ -29,8 +33,24 @@ func (s *ShowResourcesArgs) GetGroupBy() ShowResourcesGroupBy {
 	}
 }
 
+func (s *ShowResourcesArgs) GetFormat() ShowResourcesFormat {
+	switch s.Format {
+	case "table":
+		return ShowResourcesFormatTable
+	case "markdown":
+		return ShowResourcesFormatMarkdown
+	default:
+		panic(errors.Errorf("invalid format value: %s", s.Format))
+	}
+}
+
 func RunShowResources(args *ShowResourcesArgs) {
-	fmt.Printf("\n%s\n\n", ShowResources(args.GetGroupBy(), args.KubeVersions, apiVersionAndResourceAllower(args.ApiVersions, args.Resources), args.Diff))
+	fmt.Printf("\n%s\n\n",
+		ShowResources(args.GetGroupBy(),
+			args.KubeVersions,
+			apiVersionAndResourceAllower(args.ApiVersions, args.Resources),
+			args.Diff,
+			args.GetFormat()))
 }
 
 type ShowResourcesGroupBy string
@@ -51,7 +71,16 @@ func (s ShowResourcesGroupBy) Header() string {
 	}
 }
 
-func ShowResources(groupBy ShowResourcesGroupBy, versions []string, include func(string, string) bool, calculateDiff bool) string {
+type ShowResourcesFormat string
+
+const (
+	ShowResourcesFormatTable    ShowResourcesFormat = "ShowResourcesFormatTable"
+	ShowResourcesFormatMarkdown ShowResourcesFormat = "ShowResourcesFormatMarkdown"
+)
+
+// section: functionality
+
+func ShowResources(groupBy ShowResourcesGroupBy, versions []string, include func(string, string) bool, calculateDiff bool, format ShowResourcesFormat) string {
 	table := NewPivotTable(groupBy.Header(), versions)
 	for _, version := range versions {
 		kubeVersion := MustVersion(version)
@@ -81,38 +110,81 @@ func ShowResources(groupBy ShowResourcesGroupBy, versions []string, include func
 		}
 	}
 
-	if calculateDiff {
-		return table.FormattedTable(func(rowKey string, values [][]string) []string {
-			if len(values) == 0 {
-				panic(errors.Errorf("unable to calculate diff for 0 versions"))
-			}
-			prev := values[0]
-			row := []string{rowKey, formatCell(prev)}
-
-			for _, curr := range values[1:] {
-				cellDiff := diff.SliceDiff(prev, curr)
-				cellDiff.Sort()
-
-				var add, remove string
-				if len(cellDiff.Added) > 0 {
-					add = fmt.Sprintf("add:\n  %s\n\n", strings.Join(slice.Sort(cellDiff.Added), "\n  "))
+	switch format {
+	case ShowResourcesFormatTable:
+		if calculateDiff {
+			return table.ToRawTable(func(rowKey string, values [][]string) []string {
+				if len(values) == 0 {
+					panic(errors.Errorf("unable to calculate diff for 0 versions"))
 				}
-				if len(cellDiff.Removed) > 0 {
-					remove = fmt.Sprintf("remove:\n  %s\n\n", strings.Join(slice.Sort(cellDiff.Removed), "\n  "))
-				}
-				row = append(row, fmt.Sprintf("%s%s", add, remove))
+				prev := values[0]
+				row := []string{rowKey, formatCell(prev)}
 
-				prev = curr
-			}
-			return row
-		})
-	} else {
-		return table.FormattedTable(func(rowKey string, values [][]string) []string {
-			return slice.Cons(rowKey, slice.Map(formatCell, values))
-		})
+				for _, curr := range values[1:] {
+					cellDiff := diff.SliceDiff(prev, curr)
+					cellDiff.Sort()
+
+					var add, remove string
+					if len(cellDiff.Added) > 0 {
+						add = fmt.Sprintf("add:\n  %s\n\n", strings.Join(slice.Sort(cellDiff.Added), "\n  "))
+					}
+					if len(cellDiff.Removed) > 0 {
+						remove = fmt.Sprintf("remove:\n  %s\n\n", strings.Join(slice.Sort(cellDiff.Removed), "\n  "))
+					}
+					row = append(row, fmt.Sprintf("%s%s", add, remove))
+
+					prev = curr
+				}
+				return row
+			}).ToFormattedTable()
+		} else {
+			return table.ToRawTable(func(rowKey string, values [][]string) []string {
+				return slice.Cons(rowKey, slice.Map(formatCell, values))
+			}).ToFormattedTable()
+		}
+	case ShowResourcesFormatMarkdown:
+		if calculateDiff {
+			return table.ToRawTable(func(rowKey string, values [][]string) []string {
+				if len(values) == 0 {
+					panic(errors.Errorf("unable to calculate diff for 0 versions"))
+				}
+				prev := values[0]
+				row := []string{rowKey, formatMarkdownList(prev)}
+
+				for _, curr := range values[1:] {
+					cellDiff := diff.SliceDiff(prev, curr)
+					cellDiff.Sort()
+
+					var add, remove string
+					if len(cellDiff.Added) > 0 {
+						add = "add:<br>" + formatMarkdownList(slice.Sort(cellDiff.Added))
+					}
+					if len(cellDiff.Removed) > 0 {
+						remove = "remove:<br>" + formatMarkdownList(slice.Sort(cellDiff.Removed))
+					}
+					row = append(row, fmt.Sprintf("%s%s", add, remove))
+
+					prev = curr
+				}
+				return row
+			}).ToMarkdownTable()
+		} else {
+			return table.ToRawTable(func(rowKey string, values [][]string) []string {
+				return slice.Cons(rowKey, slice.Map(formatMarkdownList, values))
+			}).ToMarkdownTable()
+		}
+	default:
+		panic(errors.Errorf("invalid format: %s", format))
 	}
 }
 
 func formatCell(items []string) string {
 	return strings.Join(slice.Sort(items), "\n")
+}
+
+func formatMarkdownList(items []string) string {
+	return fmt.Sprintf("<ul>%s</ul>",
+		strings.Join(slice.Map(func(v string) string {
+			return fmt.Sprintf("<li>%s</li>", v)
+		}, slice.Sort(items)), " "))
 }

--- a/pkg/swagger/show-resources_test.go
+++ b/pkg/swagger/show-resources_test.go
@@ -16,21 +16,21 @@ func RunShowResourcesTests() {
 
 	Describe("Show resource", func() {
 		It("By resource -- no diff", func() {
-			actual := ShowResources(ShowResourcesGroupByResource, versions, include, false)
+			actual := ShowResources(ShowResourcesGroupByResource, versions, include, false, ShowResourcesFormatTable)
 			Expect(actual).To(Equal(byResourceNoDiff[1:]))
 		})
 		It("By apiversion -- no diff", func() {
-			actual := ShowResources(ShowResourcesGroupByApiVersion, versions, include, false)
+			actual := ShowResources(ShowResourcesGroupByApiVersion, versions, include, false, ShowResourcesFormatTable)
 			Expect(actual).To(Equal(byApiVersionNoDiff[1:]))
 		})
 		It("By resource -- diff", func() {
-			actual := ShowResources(ShowResourcesGroupByResource, versions, include, true)
+			actual := ShowResources(ShowResourcesGroupByResource, versions, include, true, ShowResourcesFormatTable)
 			fmt.Printf("expect:\n%s\n", byResourceWithDiff[1:])
 			fmt.Printf("actual:\n%s\n", actual)
 			Expect(actual).To(Equal(byResourceWithDiff[1:]))
 		})
 		It("By apiversion -- diff", func() {
-			actual := ShowResources(ShowResourcesGroupByApiVersion, versions, include, true)
+			actual := ShowResources(ShowResourcesGroupByApiVersion, versions, include, true, ShowResourcesFormatTable)
 			fmt.Printf("actual vs. expected:\n%s\n\n%s\n\n", actual, byApiVersionWithDiff)
 			Expect(actual).To(Equal(byApiVersionWithDiff[1:]))
 		})

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func DoOrDie(err error) {
+func Die(err error) {
 	if err != nil {
 		logrus.Fatalf("%+v", err)
 	}


### PR DESCRIPTION


closes https://github.com/mattfenwick/kubectl-schema/issues/1

# Usage

```bash
kubectl schema \
  resources \
  --kube-version 1.15.0,1.30.0 \
  --format markdown \
  --diff \
  --group-by api-version
```

# Also

s/DoOrDie/Die